### PR TITLE
Adds support for monetizing values at higher precision

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -28,12 +28,12 @@ module Monetize
 
     def parse!(input, currency = Money.default_currency, options = {})
       return input if input.is_a?(Money)
-      return from_numeric(input, currency) if input.is_a?(Numeric)
+      return from_numeric(input, currency, options) if input.is_a?(Numeric)
 
       parser = Monetize::Parser.new(input, currency, options)
       amount, currency = parser.parse
 
-      Money.from_amount(amount, currency)
+      Money.from_amount(amount, currency, options)
     rescue Money::Currency::UnknownCurrency => e
       fail ParseError, e.message
     end
@@ -42,33 +42,33 @@ module Monetize
       Collection.parse(input, currency, options)
     end
 
-    def from_string(value, currency = Money.default_currency)
+    def from_string(value, currency = Money.default_currency, options = {})
       value = BigDecimal(value.to_s)
-      Money.from_amount(value, currency)
+      Money.from_amount(value, currency, options)
     end
 
-    def from_fixnum(value, currency = Money.default_currency)
-      Money.from_amount(value, currency)
+    def from_fixnum(value, currency = Money.default_currency, options = {})
+      Money.from_amount(value, currency, options)
     end
     alias_method :from_integer, :from_fixnum
 
-    def from_float(value, currency = Money.default_currency)
-      Money.from_amount(value, currency)
+    def from_float(value, currency = Money.default_currency, options = {})
+      Money.from_amount(value, currency, options)
     end
 
-    def from_bigdecimal(value, currency = Money.default_currency)
-      Money.from_amount(value, currency)
+    def from_bigdecimal(value, currency = Money.default_currency, options = {})
+      Money.from_amount(value, currency, options)
     end
 
-    def from_numeric(value, currency = Money.default_currency)
+    def from_numeric(value, currency = Money.default_currency, options = {})
       fail ArgumentError, "'value' should be a type of Numeric" unless value.is_a?(Numeric)
-      Money.from_amount(value, currency)
+      Money.from_amount(value, currency, options)
     end
 
-    def extract_cents(input, currency = Money.default_currency)
+    def extract_cents(input, currency = Money.default_currency, options = {})
       warn '[DEPRECATION] Monetize.extract_cents is deprecated. Use Monetize.parse().cents'
 
-      money = parse(input, currency)
+      money = parse(input, currency, options)
       money.cents if money
     end
   end

--- a/lib/monetize/core_extensions/hash.rb
+++ b/lib/monetize/core_extensions/hash.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
 class Hash
-  def to_money(currency = nil)
+  def to_money(currency = Money.default_currency, options = {})
     hash_currency = self[:currency].is_a?(Hash) ? self[:currency][:iso_code] : self[:currency]
-    Money.new(self[:cents] || self[:fractional], hash_currency || currency || Money.default_currency)
+    Money.new(self[:cents] || self[:fractional], hash_currency || currency, options[:infinite_precision])
   end
 end

--- a/lib/monetize/core_extensions/nil_class.rb
+++ b/lib/monetize/core_extensions/nil_class.rb
@@ -1,5 +1,5 @@
 class NilClass
-  def to_money(currency = nil)
-    Money.new(nil, currency || Money.default_currency)
+  def to_money(currency = Money.default_currency, options = {})
+    Money.new(nil, currency, options)
   end
 end

--- a/lib/monetize/core_extensions/numeric.rb
+++ b/lib/monetize/core_extensions/numeric.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class Numeric
-  def to_money(currency = nil)
-    Monetize.from_numeric(self, currency || Money.default_currency)
+  def to_money(currency = Money.default_currency, options = {})
+    Monetize.from_numeric(self, currency, options)
   end
 end

--- a/lib/monetize/core_extensions/string.rb
+++ b/lib/monetize/core_extensions/string.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
 class String
-  def to_money(currency = nil)
-    Monetize.parse!(self, currency)
+  def to_money(currency = nil, options = {})
+    Monetize.parse!(self, currency, options)
   end
 
   def to_currency

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -136,6 +136,11 @@ describe Monetize, 'core extensions' do
         expect('10.10 USD'.to_money('USD')).to eq Money.new(10_10, 'USD')
       end
 
+      it 'accepts optional infinite precision flag' do
+        expect('10.10987'.to_money('USD', infinite_precision: true)).to eq Money.new(1010.987, 'USD', infinite_precision: true)
+        expect('10.10943'.to_money('EUR', infinite_precision: true)).to eq Money.new(1010.943, 'EUR', infinite_precision: true)
+      end
+
       it 'uses parsed currency, even if currency is passed' do
         expect('10.10 USD'.to_money('EUR')).to eq(Money.new(10_10, 'USD'))
       end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -459,13 +459,13 @@ describe Monetize do
       expect(m.currency).to eq Money::Currency.wrap('EUR')
     end
 
-    context 'infinite_precision = true' do
+    context 'default_infinite_precision = true' do
       before do
-        Money.infinite_precision = true
+        Money.default_infinite_precision = true
       end
 
       after do
-        Money.infinite_precision = false
+        Money.default_infinite_precision = false
       end
 
       it 'keeps precision' do


### PR DESCRIPTION
Requires an updated Money gem with an API accepting an options hash with
an `:infinite_precision` argument that will set the precision level on a
given Money instance.

An implementation of the changes to the Money gem required to add
support for an API of the above form can  be found here:
https://github.com/ShippingEasy/money/pull/2.